### PR TITLE
Use correct uglify-js package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "less": "^2.1.2",
-    "uglify": "^0.1.1"
+    "uglify-js": "^2.4.16"
   }
 }


### PR DESCRIPTION
Currently package.json lists "uglify"[0], instead of "uglify-js"[1]. The Makefile depends on a binary "uglifyjs", which uglify-js provides, but uglify does not. There are are also command-line switches that are only present in uglify-js, which indicates that it is the intended package to be installed.

[0] https://www.npmjs.com/package/uglify
[1] https://www.npmjs.com/package/uglify-js