### PR TITLE
Use locally installed UglifyJS to build Make targets.

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -104,7 +104,7 @@ TYPE=`echo $@ | cut -d . -f 2-`; \
 HASH=`$(HASH_FILE) $@ | cut -c 1-8`; \
 COMPRESSEDNAME=`echo $@ | sed s/raw/$$HASH/`; \
 if [ $$TYPE = js ]; then \
-uglifyjs $@ -c warnings=false -m > $$COMPRESSEDNAME; \
+node_modules/.bin/uglifyjs $@ -c warnings=false -m > $$COMPRESSEDNAME; \
 elif [ $$TYPE = css ]; then \
 $(MINIFY_CSS) $@ $$COMPRESSEDNAME; \
 else \

--- a/tools/docbuilder/Makefile
+++ b/tools/docbuilder/Makefile
@@ -25,7 +25,7 @@ docs: $(DOCS_STYLES) $(DOCS_SCRIPTS) $(DOCS) $(PATH_TO_DOC_OUTPUT)/index.html
 
 $(PATH_TO_DOC_OUTPUT)/%.js: $(PATH_TO_DOC)/scripts/%.js
 	mkdir -p $(@D)
-	uglifyjs $< -c warnings=false -m -o $@
+	node_modules/.bin/uglifyjs $< -c warnings=false -m -o $@
 
 $(PATH_TO_DOC_OUTPUT)/index.js: $(PATH_TO_DOC_OUTPUT)/_parse/index.json
 	node $(PATH_TO_DOC)/engine/writeSearchIndex.js $^ $@


### PR DESCRIPTION
This very small PR replaces occurrences of "uglifyjs" in Makefiles with "node_modules/.bin/uglifyjs". The latter is where `npm install` will link UglifyJS' bin script.

Two benefits:

1. Users who follow the README build instructions without UglifyJS installed globally can run `make` without not-in-PATH errors.

2. Make will use the version of UglifyJS specified in `package.json`, rather than whatever version a user might have globally installed. The command-line flags, argument order, etc. will work.