### PR TITLE
Support non-string XHR response with responseType

### DIFF
--- a/source/Overture/io/HttpRequest.js
+++ b/source/Overture/io/HttpRequest.js
@@ -95,6 +95,16 @@ var HttpRequest = NS.Class({
     */
     withCredentials: false,
 
+    /**
+        Property: O.HttpRequest#responseType
+        Type: String
+        Default: ''
+
+        What type should {data} in an {io:success} or {io:failure} event be?
+        Refer to {XMLHttpRequest.responseType} for permitted values.
+    */
+    responseType: '',
+
     // ---
 
     init: function ( mixin ) {
@@ -106,7 +116,6 @@ var HttpRequest = NS.Class({
         this.progress = 0;
 
         this.status = 0;
-        this.responseType = '';
         this.responseHeaders = {};
         this.response = '';
 
@@ -158,6 +167,7 @@ var HttpRequest = NS.Class({
         var data = this.get( 'data' ) || null;
         var headers = this.get( 'headers' );
         var withCredentials = this.get( 'withCredentials' );
+        var responseType = this.get( 'responseType' );
         var transport = getXhr();
         var contentType;
 
@@ -176,7 +186,8 @@ var HttpRequest = NS.Class({
         // Send the request
         this._transport = transport;
         transport.io = this;
-        transport.send( method, url, data, headers, withCredentials );
+        transport.send( method, url, data, headers, withCredentials,
+            responseType );
 
         return this;
     },


### PR DESCRIPTION
(Note: per our discussions I have assumed a browser support baseline of IE 11, though we haven’t yet merged the WeakMap code which will actively break IE<11. For this particular feature, IE 10 will still work, but IE 9 won’t work at all any more. It would be a small patch to this to make IE<10 just use `responseText` because `response` won’t be there; that would take care of `''` (text) and `json'`, though `'arraybuffer'`, `'blob'` and the rest still won’t work.)

----

Our browser support baseline all supports XMLHttpRequest.responseType,
so let’s allow using it. (Most notably, so that you can get images
as blobs rather than UTF-8 decoded strings, which makes for lots of
U+FFFD REPLACEMENT CHARACTER substitutions.)

'json' as a responseType was added later and is lacking, notably, in all
versions of IE (specifically IE 11 which we still support), but it’s
useful and easy to polyfill so I’ve polyfilled it.

There is one specific recommended change that arises out of this: if you
were using HttpRequest for JSON (e.g. `JSON.parse( event.data )` in the
`io:success` handler) you should set responseType to 'json' on the
HttpRequest. Then `event.data` will be a JSON object, or null if it’s
not valid JSON. (This implies that if you need to access the text in the
case of its not being JSON you can’t use responseType.)

Review note on XHR#getResponse concerning the removal of error handling:
the error handling was there because “Internet Explorer may throw an
error if you try to read the responseText before it is in readyState 4.”
I have confirmed that this is not the case in IE 11 for responseText or
response (which is now being used instead).